### PR TITLE
fix executable parameter info default value handling

### DIFF
--- a/peacock_trame/app/core/input/ParameterInfo.py
+++ b/peacock_trame/app/core/input/ParameterInfo.py
@@ -168,7 +168,15 @@ class ParameterInfo(object):
             parse_func = basic_type_parse_map[basic_type]
 
             if type(value) is str:
-                return [parse_func(val) for val in value.split()]
+                default_value = []
+                for val in value.split():
+                    try:
+                        default_value.append(parse_func(val.strip(' ,')))
+                    except ValueError:
+                        continue
+
+                return default_value
+                # return [parse_func(val.strip(' ,')) for val in value.split()]
             elif type(value) is list:
                 return [parse_func(val) for val in value]
             else:


### PR DESCRIPTION
some default value may not be suitable for automatic parsing
try to mitigate this by removing superfluous characters and make the default value parsing more robust